### PR TITLE
Append user permission with batch invite

### DIFF
--- a/test/fixtures/users-bad-cased-emails.csv
+++ b/test/fixtures/users-bad-cased-emails.csv
@@ -1,0 +1,2 @@
+Name,Email
+Fred,  Fred@example.com

--- a/test/integration/batch_inviting_users_test.rb
+++ b/test/integration/batch_inviting_users_test.rb
@@ -3,15 +3,49 @@ require 'test_helper'
 class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
   include ActiveJob::TestHelper
 
-
-  should "admin user can create users whose details are specified in a CSV file" do
+  should 'admin user can create users whose details are specified in a CSV file' do
     application = create(:application)
-    user = create(:user, role: "admin")
+    user = create(:user, role: 'admin')
 
     perform_batch_invite_with_user(user, application)
+
+    assert_equal 'fred@example.com', last_email.to[0]
+    assert_match 'Please confirm your account', last_email.subject
   end
 
-  should "organisation admin user can create users whose details are specified in a CSV file" do
+  should 'existing user permissions are appended - not overwritten' do
+    old_application = create(:application)
+    new_application = create(:application)
+
+    fred = create(:user, email: 'fred@example.com')
+    fred.grant_application_permission(old_application, ['signin'])
+
+    user = create(:user, role: 'admin')
+
+    perform_batch_invite_with_user(user, new_application)
+
+    fred.reload
+    assert fred.has_access_to?(old_application)
+    assert fred.has_access_to?(new_application)
+  end
+
+  should 'email case and spacing are ignored' do
+    old_application = create(:application)
+    new_application = create(:application)
+
+    fred = create(:user, email: 'fred@example.com')
+    fred.grant_application_permission(old_application, ['signin'])
+
+    user = create(:user, role: 'admin')
+
+    perform_batch_invite_with_user(user, new_application, File.join(::Rails.root, 'test', 'fixtures', 'users-bad-cased-emails.csv'))
+
+    fred.reload
+    assert fred.has_access_to?(old_application)
+    assert fred.has_access_to?(new_application)
+  end
+
+  should 'organisation admin user can create users whose details are specified in a CSV file' do
     application = create(:application)
     user = create(:user_in_organisation, role: 'organisation_admin')
     user.grant_application_permission(application, ['signin'])
@@ -19,25 +53,22 @@ class BatchInvitingUsersTest < ActionDispatch::IntegrationTest
     perform_batch_invite_with_user(user, application)
   end
 
-  def perform_batch_invite_with_user(user, application)
+  def perform_batch_invite_with_user(user, application, path = File.join(::Rails.root, 'test', 'fixtures', 'users.csv'))
     perform_enqueued_jobs do
       visit root_path
       signin_with(user)
 
       visit new_batch_invitation_path
-      path = File.join(::Rails.root, "test", "fixtures", "users.csv")
-      attach_file("Choose a CSV file of users with names and email addresses", path)
+      attach_file('Choose a CSV file of users with names and email addresses', path)
       check "Has access to #{application.name}?"
-      click_button "Create users and send emails"
+      click_button 'Create users and send emails'
 
-      assert_response_contains("Creating a batch of users")
-      assert_response_contains("1 users processed")
+      assert_response_contains('Creating a batch of users')
+      assert_response_contains('1 users processed')
 
-      invited_user = User.find_by_email("fred@example.com")
+      invited_user = User.find_by_email('fred@example.com')
       assert_not_nil invited_user
       assert invited_user.has_access_to?(application)
-      assert_equal "fred@example.com", last_email.to[0]
-      assert_match 'Please confirm your account', last_email.subject
     end
   end
 end

--- a/test/models/batch_invitation_user_test.rb
+++ b/test/models/batch_invitation_user_test.rb
@@ -38,7 +38,7 @@ class BatchInvitationUserTest < ActiveSupport::TestCase
         user = create(:batch_invitation_user, batch_invitation: @batch_invitation, email: 'a@m.com')
         user.invite(@inviting_user, [])
 
-        assert_equal "skipped", user.reload.outcome
+        assert_equal "success", user.reload.outcome
       end
     end
 


### PR DESCRIPTION
Previously it would skip any users with the 
exact same email address. 

Where the email address had different casing
it would override the existing permissions.

This change means that batch invite will add new 
permissions to the user, without affecting there 
existing permissions.