### PR TITLE
Increase timeout to 90min

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -158,7 +158,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 30.minutes
+  config.timeout_in = 90.minutes
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
In order for TPAS users to avoid needing
to log in at the start of the appointment and
at the end we have increased the timeout.

We have changed it to 90 minutes as this ensures
it fully covers the length of the appointment
and a small amount of time at the start and end
of the appointment.

__NOTE:__ This will be reviewed with the plan to move the 
timeout to the client applications if possible