### PR TITLE
Allow organisations to be created and edited

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -1,10 +1,49 @@
 class OrganisationsController < ApplicationController
   before_filter :authenticate_user!
-
+  before_filter { authorize Organisation }
   respond_to :html
 
   def index
-    authorize Organisation
     @organisations = policy_scope(Organisation)
+  end
+
+  def new
+    @organisation = Organisation.new
+  end
+
+  def create
+    @organisation = Organisation.new(organisation_params)
+    if @organisation.save
+      redirect_to organisations_path,
+        notice: "Successfully added organisation #{@organisation.name}"
+    else
+      render :new
+    end
+  end
+
+  def edit
+    @organisation = Organisation.find(params[:id])
+  end
+
+  def update
+    @organisation = Organisation.find(params[:id])
+    if @organisation.update(organisation_params)
+      redirect_to organisations_path,
+        notice: "Successfully updated organisation #{@organisation.name}"
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def organisation_params
+    params.require(:organisation).permit(
+      :slug,
+      :name,
+      :content_id,
+      :abbreviation,
+      :organisation_type
+    )
   end
 end

--- a/app/policies/organisation_policy.rb
+++ b/app/policies/organisation_policy.rb
@@ -3,6 +3,13 @@ class OrganisationPolicy < BasePolicy
     current_user.superadmin? || current_user.admin? || current_user.organisation_admin?
   end
 
+  def new?
+    current_user.superadmin? || current_user.admin?
+  end
+  alias_method :create?, :new?
+  alias_method :edit?, :new?
+  alias_method :update?, :new?
+
   def can_assign?
     return true if current_user.superadmin? || current_user.admin?
     return current_user.organisation.subtree.pluck(:id).include?(record.id) if current_user.organisation_admin?

--- a/app/views/organisations/_form_errors.html.erb
+++ b/app/views/organisations/_form_errors.html.erb
@@ -1,0 +1,9 @@
+<% if @organisation.errors.count > 0 %>
+  <div class="alert alert-danger">
+    <ul>
+      <% @organisation.errors.full_messages.each do |message| %>
+        <%= content_tag :li, message, data: track_analytics_data(:danger, message) %>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/organisations/_form_fields.html.erb
+++ b/app/views/organisations/_form_fields.html.erb
@@ -1,0 +1,24 @@
+<p class="form-group">
+  <%= f.label :slug %>
+  <%= f.text_field :slug, autofocus: true, class: 'form-control input-md-6' %>
+</p>
+
+<p class="form-group">
+  <%= f.label :name %>
+  <%= f.text_field :name, class: 'form-control input-md-6' %>
+</p>
+
+<p class="form-group">
+  <%= f.label :content_id %>
+  <%= f.text_field :content_id, class: 'form-control input-md-6' %>
+</p>
+
+<p class="form-group">
+  <%= f.label :abbreviation %>
+  <%= f.text_field :abbreviation, class: 'form-control input-md-6' %>
+</p>
+
+<p class="form-group">
+  <%= f.label :organisation_type %>
+  <%= f.text_field :organisation_type, class: 'form-control input-md-6' %>
+</p>

--- a/app/views/organisations/edit.html.erb
+++ b/app/views/organisations/edit.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "Edit #{@organisation.name}" %>
+
+<h1></h1>
+
+<%= form_for @organisation, :html => {:class => 'well add-top-margin'} do |f| %>
+
+  <%= render partial: "form_errors" %>
+  <%= render partial: "form_fields", locals: { f: f } %>
+
+  <hr>
+
+  <%= f.submit :class => 'btn btn-primary' %>
+<% end %>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -1,19 +1,31 @@
 <% content_for :title, "Organisations" %>
-<h1 class="page-title">Organisations</h1>
-<table class="table table-striped table-bordered">
+<div class="page-title clearfix remove-top-margin">
+  <h1 class="pull-left">Organisations</h1>
+  <div class="pull-right add-top-margin">
+    <%= link_to "Create organisation", new_organisation_path, class: "btn btn-success add-right-margin" %>
+  </div>
+</div>
+
+<table class="table table-striped table-bordered table-hover">
   <thead>
     <tr class="table-header">
       <th>Name</th>
+      <th>Slug</th>
+      <th>Content ID</th>
       <th>Abbreviation</th>
       <th>Organisation Type</th>
+      <th scope="col">Actions</th>
     </tr>
   </thead>
   <tbody>
     <% @organisations.each do |organisation| %>
       <tr>
-        <td><%= organisation.name %></td>
+        <td><%= link_to organisation.name, edit_organisation_path(organisation) %></td>
+        <td><%= organisation.slug %></td>
+        <td><%= organisation.content_id %></td>
         <td><%= organisation.abbreviation %></td>
         <td><%= organisation.organisation_type %></td>
+        <td><%= link_to 'Edit', edit_organisation_path(organisation) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/organisations/new.html.erb
+++ b/app/views/organisations/new.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "New Organisation" %>
+
+<h1>New Organisation</h1>
+
+<%= form_for @organisation, :html => {:class => 'well add-top-margin'} do |f| %>
+
+  <%= render partial: "form_errors" %>
+  <%= render partial: "form_fields", locals: { f: f } %>
+
+  <hr>
+
+  <%= f.submit :class => 'btn btn-primary' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Signonotron2::Application.routes.draw do
   resource :user, only: [:show]
 
   resources :batch_invitations, only: [:new, :create, :show]
-  resources :organisations, only: [:index]
+  resources :organisations, only: [:index, :new, :create, :edit, :update]
   resources :suspensions, only: [:edit, :update]
 
   resources :doorkeeper_applications, only: [:index, :edit, :update] do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -187,8 +187,8 @@ ActiveRecord::Schema.define(version: 20161019120003) do
     t.datetime "invitation_created_at"
     t.string   "otp_secret_key",               limit: 255
     t.integer  "second_factor_attempts_count",             default: 0
-    t.string   "unlock_token",                 limit: 255
     t.boolean  "require_2sv",                              default: false,    null: false
+    t.string   "unlock_token",                 limit: 255
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/spec/policies/organisation_policy_spec.rb
+++ b/spec/policies/organisation_policy_spec.rb
@@ -13,6 +13,16 @@ describe OrganisationPolicy do
     end
   end
 
+  permissions :new? do
+    it "is forbidden only for normal users" do
+      expect(subject).to permit(create(:superadmin_user), Organisation)
+      expect(subject).to permit(create(:admin_user), Organisation)
+
+      expect(subject).not_to permit(create(:organisation_admin), Organisation)
+      expect(subject).not_to permit(create(:user), Organisation)
+    end
+  end
+
   permissions :can_assign? do
     it "allows superadmins and admins to assign a user to any organisation" do
       expect(subject).to permit(create(:user_in_organisation, role: 'superadmin'), build(:organisation))

--- a/test/controllers/organisations_controller_test.rb
+++ b/test/controllers/organisations_controller_test.rb
@@ -1,20 +1,78 @@
 require 'test_helper'
 
 class OrganisationsControllerTest < ActionController::TestCase
-  setup do
-    @user = create(:admin_user)
-    sign_in @user
-  end
-
-  context "GET index" do
-    setup do
-      create(:organisation, name: "Ministry of Funk")
+  def self.test_access(&block)
+    should 'allow access for superadmin' do
+      user = create(:superadmin_user)
+      sign_in user
+      instance_eval(&block)
+      assert_response 200
     end
 
-    should "list organisations" do
-      get :index
+    should 'allow access for admin' do
+      user = create(:admin_user)
+      sign_in user
+      instance_eval(&block)
       assert_response 200
-      assert_select "td", "Ministry of Funk"
+    end
+
+    should 'not allow access for organisation admin' do
+      user = create(:organisation_admin)
+      sign_in user
+      instance_eval(&block)
+      assert_redirected_to root_url
+    end
+
+    should 'not allow access for normal user' do
+      user = create(:user)
+      sign_in user
+      instance_eval(&block)
+      assert_redirected_to root_url
+    end
+  end
+
+  context '#index' do
+    setup do
+      @user = create(:admin_user)
+      sign_in @user
+    end
+
+    context "GET index" do
+      setup do
+        create(:organisation, name: "Ministry of Funk")
+      end
+
+      should "list organisations" do
+        get :index
+        assert_response 200
+        assert_select "td", "Ministry of Funk"
+      end
+    end
+  end
+
+  context '#new' do
+    test_access do
+      get :new
+    end
+  end
+
+  context '#create' do
+    test_access do
+      post :create, organisation: { name: 'test' }
+    end
+  end
+
+  context '#edit' do
+    test_access do
+      organisation = create(:organisation)
+      get :edit, id: organisation.id
+    end
+  end
+
+  context '#update' do
+    test_access do
+      organisation = create(:organisation)
+      put :update, id: organisation.id, organisation: { slug: '' }
     end
   end
 end

--- a/test/integration/superadmin_organisation_edit_test.rb
+++ b/test/integration/superadmin_organisation_edit_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class SuperAdminApplicationEditTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  context "logged in as an superadmin" do
+    setup do
+      @organisation = create(:organisation)
+
+      @superadmin = create(:superadmin_user)
+      visit new_user_session_path
+      signin_with(@superadmin)
+      within("ul.nav") do
+        click_link "Organisations"
+      end
+    end
+
+    should "be able to update the organisation name" do
+      click_link @organisation.name
+
+      # edit organisation name
+      fill_in "Name", with: 'New organisation name'
+      click_button "Update Organisation"
+
+      @organisation.reload
+      assert_match @organisation.name, 'New organisation name'
+    end
+  end
+end


### PR DESCRIPTION
This is a deviation from the GDS signon application
as it creates organisations from a feed. As we require
an organisation for each booking location it makes 
more sense to allow them to be manually created
as each booking location goes live with online
bookings.