### PR TITLE
Allow an organisation to be assigned a parent

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -43,7 +43,8 @@ class OrganisationsController < ApplicationController
       :name,
       :content_id,
       :abbreviation,
-      :organisation_type
+      :organisation_type,
+      :parent_id
     )
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -12,6 +12,12 @@ class Organisation < ActiveRecord::Base
   validates :name, presence: true
   validates :organisation_type, presence: true
 
+  scope :allowed_parents, ->(org) do
+    exclude_ids = [org.id]
+    exclude_ids += org.descendant_ids unless org.new_record?
+    order(:name).where.not(id: exclude_ids)
+  end
+
   def name_with_abbreviation
     if abbreviation.present? && abbreviation != name
       return_value = "#{name} – #{abbreviation}"

--- a/app/views/organisations/_form_fields.html.erb
+++ b/app/views/organisations/_form_fields.html.erb
@@ -22,3 +22,8 @@
   <%= f.label :organisation_type %>
   <%= f.text_field :organisation_type, class: 'form-control input-md-6' %>
 </p>
+
+<p class="form-group">
+  <%= f.label :parent_id, 'Parent Organisation' %>
+  <%= f.collection_select :parent_id, Organisation.allowed_parents(@organisation), :id, :name, { include_blank: true }, class: 'form-control input-md-6' %>
+</p>

--- a/test/integration/superadmin_organisation_edit_test.rb
+++ b/test/integration/superadmin_organisation_edit_test.rb
@@ -23,7 +23,20 @@ class SuperAdminApplicationEditTest < ActionDispatch::IntegrationTest
       click_button "Update Organisation"
 
       @organisation.reload
-      assert_match @organisation.name, 'New organisation name'
+      assert_equal @organisation.name, 'New organisation name'
+    end
+
+    should "be able set a parent organisation" do
+      parent_organisation = create(:organisation)
+
+      click_link @organisation.name
+
+      # set organisation parent
+      select parent_organisation.name, from: "Parent Organisation"
+      click_button "Update Organisation"
+
+      @organisation.reload
+      assert_equal @organisation.parent, parent_organisation
     end
   end
 end


### PR DESCRIPTION
A organisation can not be be assigned as a parent
of any of it's decedents. this ensures we avoid
circular references.