### PR TITLE
Add phone booking permission

### DIFF
--- a/db/migrate/20170607150956_add_phone_booking_permission.rb
+++ b/db/migrate/20170607150956_add_phone_booking_permission.rb
@@ -1,0 +1,47 @@
+require_relative '../../app/models/enhancements/application'
+
+class AddPhoneBookingPermission < ActiveRecord::Migration
+  def change
+    output = Doorkeeper::Application.find_by!(name: 'PW Summary Document Generator - TPAS')
+    summary_document_generator = Doorkeeper::Application.find_by!(name: 'PW Summary Document Generator - CABs')
+
+    say "Creating new 'phone_bookings' permission for output application"
+    output_phone_bookings_permission = output.supported_permissions.find_or_create_by!(
+      name: 'phone_bookings',
+      delegatable: false,
+      grantable_from_ui: true
+    )
+
+    say "Adding 'phone_bookings' permission for existing output users"
+    users = output
+              .supported_permissions
+              .find_by(name: 'signin')
+              .user_application_permissions
+              .collect(&:user)
+
+    users.each do |user|
+      say "creating new permission for user: #{user.name}", true
+      user.application_permissions.find_or_create_by!(
+        application: output,
+        supported_permission: output_phone_bookings_permission,
+      )
+    end
+
+    say 'Adding signin permission for output to all users of old summary document generator'
+    output_signin_permission = output.supported_permissions.find_by!(name: 'signin')
+
+    users = summary_document_generator
+              .supported_permissions
+              .find_by(name: 'signin')
+              .user_application_permissions
+              .collect(&:user)
+
+    users.each do |user|
+      say "creating new permission for user: #{user.name}", true
+      user.application_permissions.find_or_create_by!(
+        application: output,
+        supported_permission: output_signin_permission
+      )
+    end
+  end
+end

--- a/db/migrate/20170609093816_remove_old_summary_document_generator_permissions.rb
+++ b/db/migrate/20170609093816_remove_old_summary_document_generator_permissions.rb
@@ -1,0 +1,31 @@
+require_relative '../../app/models/enhancements/application'
+
+class RemoveOldSummaryDocumentGeneratorPermissions < ActiveRecord::Migration
+  def change
+    summary_document_generator = Doorkeeper::Application.find_by!(name: 'PW Summary Document Generator - CABs')
+
+    say 'Removing signin permission to old summary document generator for all non admin users'
+    user_application_permissions = summary_document_generator
+              .supported_permissions
+              .find_by(name: 'signin')
+              .user_application_permissions
+
+    user_application_permissions.each do |permission|
+      user = permission.user
+      admin_permission = user
+                         .application_permissions
+                         .joins(:supported_permission)
+                         .where(
+                           application: summary_document_generator,
+                           supported_permissions: { name: 'pensionwise_admin' }
+                         )
+
+      if admin_permission.exists?
+        say "user '#{user.name}' is an admin, leaving 'signin' permission in place", true
+      else
+        say "removing 'signin' permission for user '#{user.name}'", true
+        permission.destroy
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170607150956) do
+ActiveRecord::Schema.define(version: 20170609093816) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170216105512) do
+ActiveRecord::Schema.define(version: 20170607150956) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
* Adds a new permission of `phone_bookings` to output
* For all users with `signin` permission for output, create `phone_bookings` permission permission on output.
* For all users with `signin` permission for old summary document generator, create `signin` permission on output.

**Needs to be updated to be aware of the right IDs or names of the applications in production signon**