### PR TITLE
[WIP] Create new planner permissions for schedule managers

### DIFF
--- a/db/migrate/20170609105510_add_schedule_manager_permissions.rb
+++ b/db/migrate/20170609105510_add_schedule_manager_permissions.rb
@@ -1,0 +1,27 @@
+require_relative '../../app/models/enhancements/application'
+
+class AddScheduleManagerPermissions < ActiveRecord::Migration
+  def change
+    planner = Doorkeeper::Application.find_by!(name: 'Planner Staging')
+    schedule_manager_permission = planner.supported_permissions.find_by!(name: 'schedule_manager')
+
+    say 'Removing signin permission to old summary document generator for all non admin users'
+    users = planner
+              .supported_permissions
+              .find_by(name: 'booking_manager')
+              .user_application_permissions
+              .collect(&:user)
+
+    users.each do |user|
+      if user.suspended?
+        say "user '#{user.name}' is suspended, skipping", true
+      else
+        say "creating 'schedule_manager' permission for user '#{user.name}'", true
+        user.application_permissions.find_or_create_by!(
+          application: planner,
+          supported_permission: schedule_manager_permission
+        )
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170216105512) do
+ActiveRecord::Schema.define(version: 20170609105510) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Finds all users in planner with the `booking_manager` permission and gives them the `schedule_manager` permission, skipping any that are suspended.

**Needs updating before running in production with the correct details for looking up the planner application**