### PR TITLE
Add the noindex robots metatag

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,7 @@
 <% content_for :app_title, "#{t('department.name')} Signon" %>
 <% content_for :page_title, "#{yield(:title)} | #{t('department.name')} Signon" %>
 <% content_for :head do %>
+  <meta name="robots" content="noindex" />
   <%= csrf_meta_tags %>
   <%= stylesheet_link_tag 'application' %>
   <%= javascript_include_tag 'application' %>


### PR DESCRIPTION
We were still being indexed due to backlinks from other connected
applications across staging and production.