### PR TITLE
Migrate Summary Generator permissions

### DIFF
--- a/db/migrate/20180620132327_add_dual_purpose_guider_permissions.rb
+++ b/db/migrate/20180620132327_add_dual_purpose_guider_permissions.rb
@@ -1,0 +1,27 @@
+require_relative '../../app/models/enhancements/application'
+
+class AddDualPurposeGuiderPermissions < ActiveRecord::Migration
+  APPLICATION = 'Summary Document Generator'.freeze
+  PERMISSION  = 'face_to_face_bookings'.freeze
+
+  def up
+    if app = Doorkeeper::Application.find_by(name: APPLICATION)
+      app.supported_permissions.find_or_create_by!(name: PERMISSION)
+
+      User.with_access_to_application(app).not_suspended.find_each do |user|
+        if user.permissions_for(app) == %w(signin)
+          user.grant_application_permission(app, PERMISSION)
+
+          say "Granted to #{user.name}."
+        end
+      end
+    end
+  end
+
+  def down
+    if app = Doorkeeper::Application.find_by(name: APPLICATION)
+      app.supported_permissions.where(name: PERMISSION).destroy_all
+      say "Removed the permission."
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171125195628) do
+ActiveRecord::Schema.define(version: 20180620132327) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Moves the 'signin' only users over to the new f2f guider permission.
This ensures only existing 'signin' users are assigned the new
permission, other users will need to be added on a case-by-case basis.