### PR TITLE
Ensure permissions are permissible during invites

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -81,7 +81,7 @@ class InvitationsController < Devise::InvitationsController
       :name, :email, :organisation_id,
       :invitation_token, :password,
       :password_confirmation, :require_2sv,
-      :role
+      :role, supported_permission_ids: []
     ).to_h
   end
 


### PR DESCRIPTION
When inviting a user, the supported permissions were being stripped from
the submitted params. This was due to spotty test coverage not catching
the problem during the recent upgrade to Rails 5.x.