### PR TITLE
Permit 2SV functions to organisational admins

### DIFF
--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -49,12 +49,10 @@ class UserPolicy < BasePolicy
   end
 
   def flag_2sv?
-    current_user.superadmin? || current_user.admin?
+    current_user.superadmin? || current_user.admin? || current_user.organisation_admin?
   end
 
-  def reset_2sv?
-    current_user.superadmin? || current_user.admin?
-  end
+  alias_method :reset_2sv?, :flag_2sv?
   alias_method :reset_two_step_verification?, :reset_2sv?
 
   class Scope < ::BasePolicy::Scope

--- a/lib/roles/organisation_admin.rb
+++ b/lib/roles/organisation_admin.rb
@@ -10,6 +10,7 @@ module Roles
         :organisation_id,
         :unconfirmed_email,
         :confirmation_token,
+        :require_2sv,
         { supported_permission_ids: [] },
       ]
     end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -103,21 +103,21 @@ describe UserPolicy do
   end
 
   permissions :flag_2sv? do
-    it "is only allowed for superadmins and admins" do
+    it "is only allowed for superadmins, admins and organisation admins" do
       expect(subject).to permit(build(:superadmin_user), User)
       expect(subject).to permit(create(:admin_user), User)
+      expect(subject).to permit(create(:organisation_admin), User)
 
-      expect(subject).not_to permit(create(:organisation_admin), User)
       expect(subject).not_to permit(create(:user), User)
     end
   end
 
   permissions :reset_2sv? do
-    it "is only allowed for superadmins and admins" do
+    it "is only allowed for superadmins, admins and organisation admins" do
       expect(subject).to permit(build(:superadmin_user), User)
       expect(subject).to permit(create(:admin_user), User)
+      expect(subject).to permit(create(:organisation_admin), User)
 
-      expect(subject).not_to permit(create(:organisation_admin), User)
       expect(subject).not_to permit(create(:user), User)
     end
   end

--- a/test/integration/organisation_admin_flagging_two_step_verification_test.rb
+++ b/test/integration/organisation_admin_flagging_two_step_verification_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class OrganisationAdminFlaggingTwoStepVerificationTest < ActionDispatch::IntegrationTest
+  include EmailHelpers
+  include ActiveJob::TestHelper
+
+  context 'updating a user' do
+    setup do
+      organisation_admin = create(:organisation_admin)
+      @user = create(:user_in_organisation, organisation: organisation_admin.organisation)
+      visit root_path
+      signin_with(organisation_admin)
+
+      visit edit_user_path(@user)
+    end
+
+    context 'when the user is flagged for 2SV' do
+      should 'notify the user by email' do
+        perform_enqueued_jobs do
+          check 'Ask user to set up 2-step verification'
+          click_button 'Update User'
+        end
+
+        assert last_email
+        assert_equal 'Make your Signon account more secure', last_email.subject
+        assert @user.reload.require_2sv?
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allow organisation admins to perform 2SV/2FA account actions on users
within their own organisational tree.