### PR TITLE
Add environment labelling

### DIFF
--- a/config/initializers/govuk_admin_template.rb
+++ b/config/initializers/govuk_admin_template.rb
@@ -1,3 +1,5 @@
 # We were setting app_title here, but we needed to use the department.name from
 # localisations, which aren't available in initializers. Our solution was to move
 # it to app/views/application.html.erb.
+GovukAdminTemplate.environment_style = Rails.env.staging? ? 'preview' : ENV['RAILS_ENV']
+GovukAdminTemplate.environment_label = Rails.env.titleize


### PR DESCRIPTION
This should help users know which environment they're performing actions
in.