### PR TITLE
Configure redis client correctly

### DIFF
--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,9 +1,0 @@
-development:
-  host: 127.0.0.1 %>
-  port: 6379 %>
-test:
-  host: 127.0.0.1
-  port: 6379
-production:
-  host: <%= ENV["REDIS_HOST"] %>
-  port: <%= ENV["REDIS_PORT"] %>

--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -6,12 +6,9 @@ class RedisClient
   attr_reader :connection
 
   def initialize
-    @connection = Redis.new(config.symbolize_keys)
-  end
-
-private
-
-  def config
-    Rails.application.config_for(:redis)
+    @connection = Redis.new(
+      url: ENV['REDIS_URL'],
+      ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+    )
   end
 end


### PR DESCRIPTION
This codepath wasn't used until now since we're attempting to schedule jobs that previously never ran. In doing so we've seen errors due to redis connectivity coming from the recent upgrades we performed and the need to not do peer verification.