### PR TITLE
Extend the unsuspension grace period to 30 days

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ActiveRecord::Base
   self.include_root_in_json = true
 
   SUSPENSION_THRESHOLD_PERIOD = 30.days
-  UNSUSPENSION_GRACE_PERIOD = 3.days
+  UNSUSPENSION_GRACE_PERIOD = 30.days
 
   MAX_2SV_LOGIN_ATTEMPTS = 10
   MAX_2SV_DRIFT_SECONDS = 30

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -202,9 +202,9 @@ class UserTest < ActiveSupport::TestCase
       assert_not_includes User.not_recently_unsuspended, user2
     end
 
-    should "return users who have been unsuspended more than 3 days ago" do
+    should "return users who have been unsuspended more than 30 days ago" do
       user2 = create(:suspended_user)
-      Timecop.travel(4.days.ago) { user2.unsuspend }
+      Timecop.travel(31.days.ago) { user2.unsuspend }
 
       assert_includes User.not_recently_unsuspended, user2
     end


### PR DESCRIPTION
This will make it easier for organisation managers to maintain their users.